### PR TITLE
fix: add technic and basic_machines as optional depends

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,5 @@
 player_api
 default?
 creative?
+technic?
+basic_machines?

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = biofuel
 depends = player_api
-optional_depends = default, creative
+optional_depends = default, creative, technic, basic_machines
 description = It adds a distiller and biofuel, for running biofuel powered machines
 title = Biofuel Distiller Kit


### PR DESCRIPTION
Hi,

I have found a problem in this mod - its code has an optional dependency on Technic, but this is not mentioned in the metadata files. This causes problems for the Minetest engine as it is unable to load mods in the correct order. Without this PR, Minetest crashes on my server (config [here](https://gitlab.com/linuxtardis/mtserver)):
```
2020-07-20 21:37:13: ACTION[Main]: Server: Shutting down
2020-07-20 21:37:14: ERROR[Main]: ModError: Failed to load and run script from /config/.minetest/mods/biofuel/init.lua:
2020-07-20 21:37:14: ERROR[Main]: /config/.minetest/mods/biofuel/init.lua:9: attempt to call field 'register_extractor_recipe' (a nil value)
2020-07-20 21:37:14: ERROR[Main]: stack traceback:
2020-07-20 21:37:14: ERROR[Main]: 	/config/.minetest/mods/biofuel/init.lua:9: in main chunk
```

This PR adds the dependency and with it, the mod loads correctly.

Best regards,

Jakub